### PR TITLE
Forcing a check on properties before accepting them

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -295,7 +295,12 @@ Diagram.prototype.setProp = function setProp(nm, val) {
   else if (typeof(val) === 'string') {
     val = val.trim();
   }
-  this.props[nm] = val;
+  if (this.props[nm] !== undefined) {
+    this.props[nm] = val;
+  }
+  else {
+    throw new Error("Unknown property: " + nm);
+  }
 };
 
 Diagram.prototype.compute = function compute() {


### PR DESCRIPTION
This could be better (as in it could catch the exception and report the line that the error occurs), but I'm lazy and your code is far, far more complicated than I remember.
