### PR TITLE
Fix versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "test": "ava",
     "snaps": "ava --update-snapshots",
     "coverage": "c8 -r lcov npm test",
-    "build": "genversion --es6 lib/version.js && peggy --format es lib/grammar.pegjs",
+    "build": "peggy --format es lib/grammar.pegjs",
     "release": "npm version patch && git push --follow-tags && npm publish",
     "predev": "npm run coverage",
     "dev": "light-server -q -s. -w 'lib/* # npm run coverate' -o /coverage/lcov-report/index.html",
     "watch": "watch 'npm run coverage' lib/ test/",
-    "version": "package-extract name homepage version && git add package.js"
+    "version": "package-extract name homepage version && (cd examples && make clean && make) && git add examples package.js"
   },
   "bin": {
     "quence": "bin/quence.js"


### PR DESCRIPTION
Clean up `npm run build`, and ensure that examples are re-run after a version change.